### PR TITLE
refactor(zlog): add unit test for log config flavors and format

### DIFF
--- a/zlog/log_config.go
+++ b/zlog/log_config.go
@@ -60,7 +60,7 @@ func LogsConfigDebug() LogsConfig {
 }
 
 type LogsConfig struct {
-	ConfigDeepCopy
+	ConfigDeepCopy `mapstructure:"-" json:"-" yaml:"-"`
 
 	// log level by zapcore.Level
 	// Note: debug will serialize the string to all uppercase and add color. Other levels will not be affected.

--- a/zlog/log_config_flavors.go
+++ b/zlog/log_config_flavors.go
@@ -9,7 +9,7 @@ import (
 type LogsConfigFlavors struct {
 	Name string `mapstructure:"name" json:"name" yaml:"name"`
 	LogsConfig
-	ConfigFlavorsDeepCopy
+	ConfigFlavorsDeepCopy `mapstructure:"-" json:"-" yaml:"-"`
 }
 
 type ConfigFlavorsDeepCopy interface {

--- a/zlog_test/.gitignore
+++ b/zlog_test/.gitignore
@@ -1,1 +1,2 @@
+!testdata/
 logs/

--- a/zlog_test/testdata/TestLogsConfigFlavorsFormat/debug.golden
+++ b/zlog_test/testdata/TestLogsConfigFlavorsFormat/debug.golden
@@ -1,0 +1,14 @@
+{
+  "name": "debug",
+  "level": "debug",
+  "callerHide": false,
+  "callDisableDynamic": false,
+  "callFullPath": true,
+  "stdoutEnable": true,
+  "pathBase": "logs/log",
+  "pathUseExecutable": false,
+  "maxSize": 10,
+  "maxBackups": 7,
+  "maxAge": 30,
+  "compress": false
+}

--- a/zlog_test/testdata/TestLogsConfigFlavorsFormat/default.golden
+++ b/zlog_test/testdata/TestLogsConfigFlavorsFormat/default.golden
@@ -1,0 +1,14 @@
+{
+  "name": "default",
+  "level": "info",
+  "callerHide": false,
+  "callDisableDynamic": false,
+  "callFullPath": false,
+  "stdoutEnable": true,
+  "pathBase": "logs/log",
+  "pathUseExecutable": false,
+  "maxSize": 10,
+  "maxBackups": 7,
+  "maxAge": 360,
+  "compress": true
+}

--- a/zlog_test/testdata/TestLogsConfigFlavorsFormat/production.golden
+++ b/zlog_test/testdata/TestLogsConfigFlavorsFormat/production.golden
@@ -1,0 +1,14 @@
+{
+  "name": "production",
+  "level": "warn",
+  "callerHide": false,
+  "callDisableDynamic": false,
+  "callFullPath": true,
+  "stdoutEnable": false,
+  "pathBase": "logs/log",
+  "pathUseExecutable": false,
+  "maxSize": 10,
+  "maxBackups": 7,
+  "maxAge": 720,
+  "compress": true
+}

--- a/zlog_test/testdata/TestLogsConfigFormat/debug.golden
+++ b/zlog_test/testdata/TestLogsConfigFormat/debug.golden
@@ -1,0 +1,13 @@
+{
+  "level": "debug",
+  "callerHide": false,
+  "callDisableDynamic": false,
+  "callFullPath": true,
+  "stdoutEnable": true,
+  "pathBase": "logs/log",
+  "pathUseExecutable": false,
+  "maxSize": 10,
+  "maxBackups": 7,
+  "maxAge": 30,
+  "compress": false
+}

--- a/zlog_test/testdata/TestLogsConfigFormat/default.golden
+++ b/zlog_test/testdata/TestLogsConfigFormat/default.golden
@@ -1,0 +1,13 @@
+{
+  "level": "info",
+  "callerHide": false,
+  "callDisableDynamic": false,
+  "callFullPath": false,
+  "stdoutEnable": true,
+  "pathBase": "logs/log",
+  "pathUseExecutable": false,
+  "maxSize": 10,
+  "maxBackups": 7,
+  "maxAge": 360,
+  "compress": true
+}

--- a/zlog_test/testdata/TestLogsConfigFormat/production.golden
+++ b/zlog_test/testdata/TestLogsConfigFormat/production.golden
@@ -1,0 +1,13 @@
+{
+  "level": "warn",
+  "callerHide": false,
+  "callDisableDynamic": false,
+  "callFullPath": true,
+  "stdoutEnable": false,
+  "pathBase": "logs/log",
+  "pathUseExecutable": false,
+  "maxSize": 10,
+  "maxBackups": 7,
+  "maxAge": 720,
+  "compress": true
+}

--- a/zlog_test/zlog_config_flavors_test.go
+++ b/zlog_test/zlog_config_flavors_test.go
@@ -1,6 +1,7 @@
 package zlog_test
 
 import (
+	"github.com/sebdah/goldie/v2"
 	"github.com/sinlov-go/zlog-zap-wrapper/zlog"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -80,6 +81,67 @@ func TestLogsConfigFlavors(t *testing.T) {
 			errDeepCopyFrom := logsNewCopyFlavors.DeepCopyFrom(logsCfgFlavors)
 			assert.Equal(t, tc.wantErr, errDeepCopyFrom != nil)
 			assert.Equal(t, logsCfgFlavors, *copyNew)
+		})
+	}
+}
+
+func TestLogsConfigFlavorsFormat(t *testing.T) {
+	// mock LogsConfigFlavorsFormat
+	type args struct {
+		name   string
+		config zlog.LogsConfig
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "error",
+			args: args{
+				config: zlog.LogsConfigDefault(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "default",
+			args: args{
+				name:   "default",
+				config: zlog.LogsConfigDefault(),
+			},
+		},
+		{
+			name: "production",
+			args: args{
+				name:   "production",
+				config: zlog.LogsConfigProduction(),
+			},
+		},
+		{
+			name: "debug",
+			args: args{
+				name:   "debug",
+				config: zlog.LogsConfigDebug(),
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := goldie.New(t,
+				goldie.WithDiffEngine(goldie.ClassicDiff),
+			)
+
+			logsCfgFlavors := zlog.LogsConfigFlavors{}
+			errCopyFromConfig := logsCfgFlavors.DeepCopyFromConfig(tc.args.name, tc.args.config)
+			assert.Equal(t, tc.wantErr, errCopyFromConfig != nil)
+			if tc.wantErr {
+				t.Logf("err DeepCopyFromConfig %v", errCopyFromConfig)
+				return
+			}
+
+			// do LogsConfigFlavorsFormat
+			// verify LogsConfigFlavorsFormat
+			g.AssertJson(t, t.Name(), logsCfgFlavors)
 		})
 	}
 }

--- a/zlog_test/zlog_config_test.go
+++ b/zlog_test/zlog_config_test.go
@@ -1,0 +1,48 @@
+package zlog_test
+
+import (
+	"github.com/sebdah/goldie/v2"
+	"github.com/sinlov-go/zlog-zap-wrapper/zlog"
+	"testing"
+)
+
+func TestLogsConfigFormat(t *testing.T) {
+	// mock LogsConfigFlavorsFormat
+	type args struct {
+		config zlog.LogsConfig
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "default",
+			args: args{
+				config: zlog.LogsConfigDefault(),
+			},
+		},
+		{
+			name: "production",
+			args: args{
+				config: zlog.LogsConfigProduction(),
+			},
+		},
+		{
+			name: "debug",
+			args: args{
+				config: zlog.LogsConfigDebug(),
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := goldie.New(t,
+				goldie.WithDiffEngine(goldie.ClassicDiff),
+			)
+
+			// verify LogsConfigFlavorsFormat
+			g.AssertJson(t, t.Name(), tc.args.config)
+		})
+	}
+}


### PR DESCRIPTION
- Add unit tests for LogsConfigFlavorsFormat and LogsConfigFormat
- Update LogsConfig and LogsConfigFlavors struct to ignore ConfigDeepCopy and ConfigFlavorsDeepCopy fields in JSON and YAML serialization
- Add golden files for test data
- Update .gitignore to include testdata directory
